### PR TITLE
PostgreSQL Database got error when trying to access mc_time_mgmt_project_controller - group by missing field

### DIFF
--- a/app/controllers/mc_time_mgmt_project_controller.rb
+++ b/app/controllers/mc_time_mgmt_project_controller.rb
@@ -59,7 +59,7 @@ class McTimeMgmtProjectController < ApplicationController
                                              where issues.project_id in (#{stringSqlProjectsSubPorjects})
                                              and issues.fixed_version_id = versions.id
                                              and due_date <= versions.effective_date
-                                             group by versions.name, versions.effective_date
+                                             group by versions.id, versions.name, versions.effective_date
                                              order by versions.effective_date;")
                                       
 


### PR DESCRIPTION
I've got an sql error when tried to access mc_time_mgmt_project controller and I figured that it was because you missed to put an field on groub by conditions. It is necessary to work with postgresql server. Is now fixed.
