### PR TITLE
Fixes for Issue #56 - Time management graphs

### DIFF
--- a/app/controllers/mc_time_mgmt_project_controller.rb
+++ b/app/controllers/mc_time_mgmt_project_controller.rb
@@ -44,7 +44,6 @@ class McTimeMgmtProjectController < ApplicationController
                                               from issues i, time_entries t
                                               where i.project_id in (#{stringSqlProjectsSubProjects})
                                               and i.project_id = t.project_id
-                                              and i.parent_id is null
                                               and i.id = t.issue_id
                                               and i.fixed_version_id = versions.id
                                               and t.spent_on <= versions.effective_date) as sumspenthours


### PR DESCRIPTION
Those commits fix the following problems:

1 - Bug in the issuesSpentHours query - when calculating sum(i.estimated_hours), issues with parents were taken into account.
2 - Bug in retrieval of time entries - the spent_on field should be considered instead of the created_on field.
